### PR TITLE
fixed the display name of the __text section on Mach-O

### DIFF
--- a/src/app/assembly.rs
+++ b/src/app/assembly.rs
@@ -203,7 +203,7 @@ impl App
                     lines.push(
                         AssemblyLine::SectionTag(
                             SectionTag {
-                                name: ".text".to_string(),
+                                name: section.name.clone(),
                                 file_address: section.file_offset,
                                 virtual_address: section.virtual_address,
                                 size: section.size as usize


### PR DESCRIPTION
It was displayed as .text instead of __text