### PR TITLE
Fixed cursor behavior when using end and home buttons

### DIFF
--- a/src/app/assembly.rs
+++ b/src/app/assembly.rs
@@ -608,7 +608,7 @@ mod test
         assert!(text_found);
 
         // move one byte forward
-        app.move_cursor(2,0);
+        app.move_cursor(2,0, false);
 
         app.patch("jmp rax");
         let expected_data = vec![0x90, 0xff, 0xe0, 0x48, 0x89, 0xc1, 0x48, 0x89, 0xc0];

--- a/src/app/events.rs
+++ b/src/app/events.rs
@@ -13,16 +13,16 @@ impl App
                 match event.code
                 {
                     KeyCode::Up => {
-                        self.move_cursor(0, -1);
+                        self.move_cursor(0, -1, false);
                     },
                     KeyCode::Down => {
-                        self.move_cursor(0, 1);
+                        self.move_cursor(0, 1, false);
                     },
                     KeyCode::Left => {
-                        self.move_cursor(-1, 0);
+                        self.move_cursor(-1, 0, false);
                     },
                     KeyCode::Right => {
-                        self.move_cursor(1, 0);
+                        self.move_cursor(1, 0, false);
                     },
                     KeyCode::PageUp => {
                         self.move_cursor_page_up();
@@ -99,16 +99,16 @@ impl App
                 match event.kind
                 {
                     event::MouseEventKind::ScrollUp => {
-                        self.move_cursor(0, -1);
+                        self.move_cursor(0, -1, false);
                     },
                     event::MouseEventKind::ScrollDown => {
-                        self.move_cursor(0, 1);
+                        self.move_cursor(0, 1, false);
                     },
                     event::MouseEventKind::ScrollLeft => {
-                        self.move_cursor(-1, 0);
+                        self.move_cursor(-1, 0, false);
                     },
                     event::MouseEventKind::ScrollRight => {
-                        self.move_cursor(1, 0);
+                        self.move_cursor(1, 0, false);
                     },
                     _ => {}
                 }


### PR DESCRIPTION
Now every function related to manual cursor positioning uses move_cursor