### PR TITLE
Fixed default settings path for MacOS

### DIFF
--- a/src/app/settings/settings.rs
+++ b/src/app/settings/settings.rs
@@ -46,12 +46,8 @@ impl Settings
 
     fn get_default_settings_path() -> Option<PathBuf>
     {
-        let home = dirs::home_dir()?;
-        Some(match std::env::consts::OS
-        {
-            "windows" => home.join("AppData").join("Local"),
-            _ => home.join(".config")
-        }.join("HexPatch").join("settings.json"))
+        let config = dirs::config_dir()?;
+        Some(config.join("HexPatch").join("settings.json"))
     }
 
     pub fn load_or_create(path: Option<&Path>) -> Result<Settings, String>


### PR DESCRIPTION
config dir is get with dirs::config_dir()