### PR TITLE
Feature/light theme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,13 @@ build = "build.rs"
 winres = "0.1"
 
 [dependencies]
+async-std = "1.12.0"
 bitflags = { version = "2.6", features = ["std"] }
 capstone = "0.12"
 clap = { version = "4.5", features = ["derive"] }
 crossterm = { version = "0.28", features = ["serde"] }
 dirs = "5.0"
+is-terminal = "0.4.13"
 keystone-engine = "0.1"
 macro_rules_attribute = "0.2"
 mlua = { version = "0.9", features = ["lua54", "vendored", "serialize"] }
@@ -41,4 +43,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 symbolic-demangle = "12.10"
 tempfile = "3.12"
+thiserror = "1.0.63"
 tokio = "1.39"
+winapi = "0.3.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,13 @@ build = "build.rs"
 winres = "0.1"
 
 [dependencies]
-async-std = "1.12.0"
+async-std = "1.12"
 bitflags = { version = "2.6", features = ["std"] }
 capstone = "0.12"
 clap = { version = "4.5", features = ["derive"] }
 crossterm = { version = "0.28", features = ["serde"] }
 dirs = "5.0"
-is-terminal = "0.4.13"
+is-terminal = "0.4"
 keystone-engine = "0.1"
 macro_rules_attribute = "0.2"
 mlua = { version = "0.9", features = ["lua54", "vendored", "serialize"] }
@@ -43,6 +43,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 symbolic-demangle = "12.10"
 tempfile = "3.12"
-thiserror = "1.0.63"
+thiserror = "1.0"
 tokio = "1.39"
-winapi = "0.3.9"
+
+[target.'cfg(windows)'.dependencies]
+winapi = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ HexPatch is a binary patcher and editor with terminal user interface (TUI),
 it's capable of disassembling instructions and assembling patches.
 It supports a variety of architectures and file formats.
 Also, it can edit remote files via SSH."""
-version = "1.8.0"
+version = "1.9.0"
 authors = ["Ettore Ricci"]
 edition = "2021"
 readme = "docs/README.md"

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -11,6 +11,8 @@ You can specify a different configuration file to use with the `--config` flag.
 
 If the file or directory doesn't exist, it will be created with the default settings.
 
+To improve forward compatibility, the app will not create a file with the default settings if the `--config` flag is not used. This is to avoid creating a config file that will override new default settings in future versions of the app.
+
 Settings are stored in JSON format and have the following structure:
 
 ```json

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -287,7 +287,7 @@ The following app settings can be customized in the app settings:
 |------|------|-------------|
 |history_limit|usize|Maximum number of modifications that are stored in the undo/redo history.|
 |log_limit|usize|Maximum number of log messages that are stored in the log.|
-|theme|Option<String>|The name of the theme to use. The available themes are: `"auto"`, `"dark"`, `"light"`. `"auto"` choses automatically between `"dark"` and `"light"` based on the background color of the terminal. By default, the theme is `"auto"`.|
+|theme|Option<String>|The name of the theme to use. The available themes are: `"auto"`, `"dark"`, `"light"`. `"auto"` chooses automatically between `"dark"` and `"light"` based on the background color of the terminal. By default, the theme is `"auto"`.|
 
 ## Custom
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -31,6 +31,7 @@ Settings are stored in JSON format and have the following structure:
 ```
 
 If a setting is not present in the file, the default value will be used.
+For `color` settings, the default value changes based on the theme specified in the `app` settings, if the theme is not specified, the default theme is `"auto"` and if the detection fails, the `"dark"` theme is used.
 
 You can find the default settings [here](https://github.com/Etto48/hexpatch/blob/master/test/default_settings.json).
 You can also generate the same file by running `hexpatch --config <CONFIG_PATH>` passing in a path that doesn't exist yet, the file will be created there.

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -94,7 +94,7 @@ The following styles can be customized in the color settings:
 |patch_old_rest|Remaining bytes that are neither patched nor belonging to the old instruction in the patch popup.|
 |patch_line_number|Line number in the patch popup.|
 |help_command|Key combination in the help popup.|
-|hep_description|Command description in the help popup.|
+|help_description|Command description in the help popup.|
 |yes|"Yes" in popups with choiches when not selected.|
 |yes_selected|"Yes" in popups with choiches when selected.|
 |no|"No" in popups with choiches when not selected.|
@@ -287,6 +287,7 @@ The following app settings can be customized in the app settings:
 |------|------|-------------|
 |history_limit|usize|Maximum number of modifications that are stored in the undo/redo history.|
 |log_limit|usize|Maximum number of log messages that are stored in the log.|
+|theme|Option<String>|The name of the theme to use. The available themes are: `"auto"`, `"dark"`, `"light"`. `"auto"` choses automatically between `"dark"` and `"light"` based on the background color of the terminal. By default, the theme is `"auto"`.|
 
 ## Custom
 

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::module_inception)]
 use std::time::Duration;
 
+use crate::detect_theme::Theme;
 use crossterm::event;
 use ratatui::{
     backend::Backend,
@@ -8,7 +9,6 @@ use ratatui::{
     text::{Line, Text},
     widgets::{Block, Borders, Clear, ScrollbarOrientation, ScrollbarState},
 };
-use crate::detect_theme::Theme;
 
 use super::{
     asm::assembly_line::AssemblyLine,

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -8,6 +8,7 @@ use ratatui::{
     text::{Line, Text},
     widgets::{Block, Borders, Clear, ScrollbarOrientation, ScrollbarState},
 };
+use crate::detect_theme::Theme;
 
 use super::{
     asm::assembly_line::AssemblyLine,
@@ -101,9 +102,10 @@ impl App {
     pub fn new<B: Backend>(
         args: Args,
         terminal: &mut ratatui::Terminal<B>,
+        terminal_theme: Theme,
     ) -> Result<Self, String> {
         let mut logger = Logger::default();
-        let settings = match Settings::load_or_create(args.config.as_deref()) {
+        let settings = match Settings::load_or_create(args.config.as_deref(), terminal_theme) {
             Ok(settings) => settings,
             Err(e) => {
                 logger.log(

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::module_inception)]
 use std::time::Duration;
 
-use crate::detect_theme::Theme;
+use crate::detect_theme::{self, Theme};
 use crossterm::event;
 use ratatui::{
     backend::Backend,
@@ -102,9 +102,19 @@ impl App {
     pub fn new<B: Backend>(
         args: Args,
         terminal: &mut ratatui::Terminal<B>,
-        terminal_theme: Theme,
+        terminal_theme: Result<Theme, detect_theme::Error>,
     ) -> Result<Self, String> {
         let mut logger = Logger::default();
+        let terminal_theme = match terminal_theme {
+            Ok(theme) => theme,
+            Err(e) => {
+                logger.log(
+                    NotificationLevel::Error,
+                    &format!("Error detecting terminal theme: {e}"),
+                );
+                Theme::Dark
+            }
+        };
         let settings = match Settings::load_or_create(args.config.as_deref(), terminal_theme) {
             Ok(settings) => settings,
             Err(e) => {

--- a/src/app/asm/assembly.rs
+++ b/src/app/asm/assembly.rs
@@ -450,7 +450,7 @@ mod test {
             },
             file_address,
         });
-        let line = al.to_line(&ColorSettings::default(), 0, &Header::None, 0);
+        let line = al.to_line(&ColorSettings::get_default_dark_theme(), 0, &Header::None, 0);
 
         let contains_mnemonic = line.spans.iter().any(|span| span.content.contains("mov"));
         assert!(contains_mnemonic);
@@ -485,7 +485,7 @@ mod test {
             size: section_size,
         });
 
-        let line = al.to_line(&ColorSettings::default(), 0, &Header::None, 0);
+        let line = al.to_line(&ColorSettings::get_default_dark_theme(), 0, &Header::None, 0);
 
         let contains_section_name = line.spans.iter().any(|span| span.content.contains(".text"));
         assert!(contains_section_name);

--- a/src/app/asm/assembly.rs
+++ b/src/app/asm/assembly.rs
@@ -450,7 +450,12 @@ mod test {
             },
             file_address,
         });
-        let line = al.to_line(&ColorSettings::get_default_dark_theme(), 0, &Header::None, 0);
+        let line = al.to_line(
+            &ColorSettings::get_default_dark_theme(),
+            0,
+            &Header::None,
+            0,
+        );
 
         let contains_mnemonic = line.spans.iter().any(|span| span.content.contains("mov"));
         assert!(contains_mnemonic);
@@ -485,7 +490,12 @@ mod test {
             size: section_size,
         });
 
-        let line = al.to_line(&ColorSettings::get_default_dark_theme(), 0, &Header::None, 0);
+        let line = al.to_line(
+            &ColorSettings::get_default_dark_theme(),
+            0,
+            &Header::None,
+            0,
+        );
 
         let contains_section_name = line.spans.iter().any(|span| span.content.contains(".text"));
         assert!(contains_section_name);

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -29,7 +29,7 @@ impl HelpLine {
             .push(Span::styled(": ", color_settings.menu_text));
         line.spans.push(Span::styled(
             self.description.clone(),
-            color_settings.menu_text,
+            color_settings.help_description,
         ));
         line.left_aligned()
     }

--- a/src/app/popup/popup_state.rs
+++ b/src/app/popup/popup_state.rs
@@ -851,7 +851,7 @@ mod tests {
 
     #[test]
     fn test_get_line_from_string_and_cursor() {
-        let color_settings = ColorSettings::default();
+        let color_settings = ColorSettings::get_default_dark_theme();
         let s = "Hello, World!";
         let line =
             App::get_line_from_string_and_cursor(&color_settings, s, 0, "Placeholder", 8, true);
@@ -874,7 +874,7 @@ mod tests {
 
     #[test]
     fn test_get_multiline_from_string_and_cursor() {
-        let color_settings = ColorSettings::default();
+        let color_settings = ColorSettings::get_default_dark_theme();
         let s = "Hello, World!\nThis is a test\n";
         let (lines, _) =
             App::get_multiline_from_string_and_cursor(&color_settings, s, 0, "Placeholder", 40);

--- a/src/app/settings/app_settings.rs
+++ b/src/app/settings/app_settings.rs
@@ -8,6 +8,7 @@ use super::Settings;
 pub struct AppSettings {
     pub history_limit: usize,
     pub log_limit: usize,
+    pub theme: Option<String>,
 }
 
 impl AppSettings {
@@ -42,6 +43,7 @@ impl Default for AppSettings {
         Self {
             history_limit: 1024,
             log_limit: 1024,
+            theme: None,
         }
     }
 }

--- a/src/app/settings/color_settings.rs
+++ b/src/app/settings/color_settings.rs
@@ -90,7 +90,7 @@ impl ColorSettings {
 
     pub fn get_default_light_theme() -> Self {
         let status_bar_bg = Color::Rgb(246, 184, 76);
-        let dark_yellow = Color::Rgb(246, 184, 76);
+        let dark_yellow = Color::Rgb(243, 164, 27);
         let light_brown = Color::Rgb(202, 123, 63);
         let dark_orange = Color::Rgb(218, 152, 37);
         let desaturated_dark_brown = Color::Rgb(98, 83, 75);

--- a/src/app/settings/color_settings.rs
+++ b/src/app/settings/color_settings.rs
@@ -1,11 +1,16 @@
+use std::collections::HashMap;
+
 use ratatui::style::{Color, Modifier, Style};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
+use crate::detect_theme::Theme;
 
 use crate::app::App;
-use crate::RegisterColorSettings;
+use crate::{EditColorSettings, RegisterColorSettings};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+use super::app_settings::AppSettings;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(EditColorSettings!)]
 #[derive(RegisterColorSettings!)]
 pub struct ColorSettings {
     pub address_selected: Style,
@@ -40,7 +45,7 @@ pub struct ColorSettings {
     pub patch_line_number: Style,
 
     pub help_command: Style,
-    pub hep_description: Style,
+    pub help_description: Style,
 
     pub yes: Style,
     pub yes_selected: Style,
@@ -75,8 +80,98 @@ pub struct ColorSettings {
     pub placeholder: Style,
 }
 
-impl Default for ColorSettings {
-    fn default() -> Self {
+impl ColorSettings {
+    pub fn get_default_theme(theme: Theme) -> Self {
+        match theme {
+            Theme::Light => Self::get_default_light_theme(),
+            Theme::Dark => Self::get_default_dark_theme(),
+        }
+    }
+
+    pub fn get_default_light_theme() -> Self {
+        let status_bar_bg = Color::Rgb(246, 184, 76);
+        let dark_yellow = Color::Rgb(246, 184, 76);
+        let light_brown = Color::Rgb(202, 123, 63);
+        let dark_brown = Color::Rgb(131, 91, 22);
+        let desaturated_dark_brown = Color::Rgb(98, 83, 75);
+        Self {
+            address_selected: Style::default().fg(Color::White).bg(Color::Black),
+            address_default: Style::default().fg(Color::Gray),
+
+            hex_selected: Style::default().fg(Color::White).bg(Color::Black),
+            hex_null: Style::default().fg(Color::Gray),
+            hex_alphanumeric: Style::default().fg(light_brown),
+            hex_symbol: Style::default()
+                .fg(light_brown)
+                .add_modifier(Modifier::DIM),
+            hex_end_of_line: Style::default().fg(Color::Red),
+            hex_whitespace: Style::default().fg(desaturated_dark_brown),
+            hex_current_instruction: Style::default()
+                .fg(Color::White)
+                .bg(dark_brown),
+            hex_current_section: Style::default()
+                .fg(Color::White)
+                .bg(dark_brown),
+            hex_default: Style::default(),
+
+            text_selected: Style::default().fg(Color::White).bg(Color::Black),
+
+            assembly_symbol: Style::default().fg(Color::Green),
+            assembly_selected: Style::default().fg(Color::White).bg(Color::Black),
+            assembly_address: Style::default().fg(Color::Gray),
+            assembly_virtual_address: Style::default()
+                .fg(Color::Gray)
+                .add_modifier(Modifier::DIM),
+            assembly_nop: Style::default().fg(Color::Gray),
+            assembly_bad: Style::default().fg(Color::Red),
+            assembly_section: Style::default().fg(Color::Blue),
+            assembly_entry_point: Style::default().fg(dark_yellow),
+            assembly_default: Style::default().fg(light_brown),
+
+            patch_patched_less_or_equal: Style::default().fg(Color::Green),
+            patch_patched_greater: Style::default().fg(dark_yellow),
+            patch_old_instruction: Style::default().fg(Color::Red),
+            patch_old_rest: Style::default().fg(Color::Gray),
+            patch_line_number: Style::default().fg(Color::Gray),
+
+            help_command: Style::default().fg(Color::LightGreen),
+            help_description: Style::default().fg(Color::DarkGray),
+
+            yes: Style::default().fg(Color::Green),
+            yes_selected: Style::default().fg(Color::Black).bg(Color::Green),
+            no: Style::default().fg(Color::Red),
+            no_selected: Style::default().fg(Color::Black).bg(Color::Red),
+            menu_text: Style::default().fg(Color::Black),
+            menu_text_selected: Style::default().fg(Color::White).bg(Color::Black),
+
+            insert_text_status: Style::default().fg(Color::Black).bg(status_bar_bg),
+
+            command_name: Style::default().fg(Color::LightGreen),
+            command_description: Style::default().fg(Color::Gray),
+            command_selected: Style::default().fg(Color::White).bg(Color::Black),
+
+            path_dir: Style::default().fg(Color::Blue),
+            path_file: Style::default().fg(dark_yellow),
+            path_selected: Style::default().fg(Color::White).bg(Color::Black),
+
+            log_info: Style::default().fg(Color::LightBlue),
+            log_debug: Style::default().fg(Color::LightGreen),
+            log_warning: Style::default().fg(dark_yellow),
+            log_error: Style::default().fg(Color::Red),
+            log_message: Style::default().fg(Color::Black),
+
+            status_bar: Style::default().fg(Color::Black).bg(status_bar_bg),
+            status_info: Style::default().fg(Color::Blue).bg(status_bar_bg),
+            status_debug: Style::default().fg(Color::Green).bg(status_bar_bg),
+            status_warning: Style::default().fg(Color::Yellow).bg(status_bar_bg),
+            status_error: Style::default().fg(Color::Red).bg(status_bar_bg),
+
+            scrollbar: Style::default().fg(status_bar_bg).bg(Color::Gray),
+            placeholder: Style::default().fg(Color::Gray),
+        }
+    }
+
+    pub fn get_default_dark_theme() -> Self {
         let status_bar_bg = Color::Rgb(255, 223, 168);
         Self {
             address_selected: Style::default().fg(Color::Black).bg(Color::White),
@@ -119,7 +214,7 @@ impl Default for ColorSettings {
             patch_line_number: Style::default().fg(Color::DarkGray),
 
             help_command: Style::default().fg(Color::LightGreen),
-            hep_description: Style::default().fg(Color::Gray),
+            help_description: Style::default().fg(Color::Gray),
 
             yes: Style::default().fg(Color::Green),
             yes_selected: Style::default().fg(Color::Black).bg(Color::Green),
@@ -153,6 +248,27 @@ impl Default for ColorSettings {
             scrollbar: Style::default().fg(status_bar_bg).bg(Color::DarkGray),
             placeholder: Style::default().fg(Color::DarkGray),
         }
+    }
+
+    pub fn from_map(map: &HashMap<String, Style>, app_settings: &AppSettings, terminal_theme: Theme) -> Result<Self, String> {
+        let theme = match &app_settings.theme
+        {
+            Some(theme) if theme.to_lowercase() == "light" => Theme::Light,
+            Some(theme) if theme.to_lowercase() == "dark" => Theme::Dark,
+            any => {
+                if let Some(theme) = any {
+                    if theme.to_lowercase() != "auto" {
+                        return Err(format!("Invalid theme: {}", theme));
+                    }
+                }
+                terminal_theme
+            }
+        };
+        let mut color_settings = Self::get_default_theme(theme);
+        color_settings.edit_color_settings(&map).map_err(
+            |e| format!("Failed to load color settings: {}", e)
+        )?;
+        Ok(color_settings)
     }
 }
 

--- a/src/app/settings/color_settings.rs
+++ b/src/app/settings/color_settings.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
+use crate::detect_theme::Theme;
 use ratatui::style::{Color, Modifier, Style};
 use serde::Serialize;
-use crate::detect_theme::Theme;
 
 use crate::app::App;
 use crate::{EditColorSettings, RegisterColorSettings};
@@ -101,17 +101,11 @@ impl ColorSettings {
             hex_selected: Style::default().fg(Color::White).bg(Color::Black),
             hex_null: Style::default().fg(Color::Gray),
             hex_alphanumeric: Style::default().fg(light_brown),
-            hex_symbol: Style::default()
-                .fg(light_brown)
-                .add_modifier(Modifier::DIM),
+            hex_symbol: Style::default().fg(light_brown).add_modifier(Modifier::DIM),
             hex_end_of_line: Style::default().fg(Color::Red),
             hex_whitespace: Style::default().fg(desaturated_dark_brown),
-            hex_current_instruction: Style::default()
-                .fg(Color::White)
-                .bg(dark_brown),
-            hex_current_section: Style::default()
-                .fg(Color::White)
-                .bg(dark_brown),
+            hex_current_instruction: Style::default().fg(Color::White).bg(dark_brown),
+            hex_current_section: Style::default().fg(Color::White).bg(dark_brown),
             hex_default: Style::default(),
 
             text_selected: Style::default().fg(Color::White).bg(Color::Black),
@@ -119,9 +113,7 @@ impl ColorSettings {
             assembly_symbol: Style::default().fg(Color::Green),
             assembly_selected: Style::default().fg(Color::White).bg(Color::Black),
             assembly_address: Style::default().fg(Color::Gray),
-            assembly_virtual_address: Style::default()
-                .fg(Color::Gray)
-                .add_modifier(Modifier::DIM),
+            assembly_virtual_address: Style::default().fg(Color::Gray).add_modifier(Modifier::DIM),
             assembly_nop: Style::default().fg(Color::Gray),
             assembly_bad: Style::default().fg(Color::Red),
             assembly_section: Style::default().fg(Color::Blue),
@@ -250,9 +242,12 @@ impl ColorSettings {
         }
     }
 
-    pub fn from_map(map: &HashMap<String, Style>, app_settings: &AppSettings, terminal_theme: Theme) -> Result<Self, String> {
-        let theme = match &app_settings.theme
-        {
+    pub fn from_map(
+        map: &HashMap<String, Style>,
+        app_settings: &AppSettings,
+        terminal_theme: Theme,
+    ) -> Result<Self, String> {
+        let theme = match &app_settings.theme {
             Some(theme) if theme.to_lowercase() == "light" => Theme::Light,
             Some(theme) if theme.to_lowercase() == "dark" => Theme::Dark,
             any => {
@@ -265,9 +260,9 @@ impl ColorSettings {
             }
         };
         let mut color_settings = Self::get_default_theme(theme);
-        color_settings.edit_color_settings(&map).map_err(
-            |e| format!("Failed to load color settings: {}", e)
-        )?;
+        color_settings
+            .edit_color_settings(map)
+            .map_err(|e| format!("Failed to load color settings: {}", e))?;
         Ok(color_settings)
     }
 }

--- a/src/app/settings/color_settings.rs
+++ b/src/app/settings/color_settings.rs
@@ -92,7 +92,7 @@ impl ColorSettings {
         let status_bar_bg = Color::Rgb(246, 184, 76);
         let dark_yellow = Color::Rgb(246, 184, 76);
         let light_brown = Color::Rgb(202, 123, 63);
-        let dark_brown = Color::Rgb(131, 91, 22);
+        let dark_orange = Color::Rgb(218, 152, 37);
         let desaturated_dark_brown = Color::Rgb(98, 83, 75);
         Self {
             address_selected: Style::default().fg(Color::White).bg(Color::Black),
@@ -104,8 +104,8 @@ impl ColorSettings {
             hex_symbol: Style::default().fg(light_brown).add_modifier(Modifier::DIM),
             hex_end_of_line: Style::default().fg(Color::Red),
             hex_whitespace: Style::default().fg(desaturated_dark_brown),
-            hex_current_instruction: Style::default().fg(Color::White).bg(dark_brown),
-            hex_current_section: Style::default().fg(Color::White).bg(dark_brown),
+            hex_current_instruction: Style::default().fg(Color::White).bg(dark_orange),
+            hex_current_section: Style::default().fg(Color::White).bg(dark_orange),
             hex_default: Style::default(),
 
             text_selected: Style::default().fg(Color::White).bg(Color::Black),
@@ -126,28 +126,28 @@ impl ColorSettings {
             patch_old_rest: Style::default().fg(Color::Gray),
             patch_line_number: Style::default().fg(Color::Gray),
 
-            help_command: Style::default().fg(Color::LightGreen),
+            help_command: Style::default().fg(Color::Green),
             help_description: Style::default().fg(Color::DarkGray),
 
             yes: Style::default().fg(Color::Green),
-            yes_selected: Style::default().fg(Color::Black).bg(Color::Green),
+            yes_selected: Style::default().fg(Color::White).bg(Color::Green),
             no: Style::default().fg(Color::Red),
-            no_selected: Style::default().fg(Color::Black).bg(Color::Red),
+            no_selected: Style::default().fg(Color::White).bg(Color::Red),
             menu_text: Style::default().fg(Color::Black),
             menu_text_selected: Style::default().fg(Color::White).bg(Color::Black),
 
             insert_text_status: Style::default().fg(Color::Black).bg(status_bar_bg),
 
-            command_name: Style::default().fg(Color::LightGreen),
-            command_description: Style::default().fg(Color::Gray),
+            command_name: Style::default().fg(Color::Green),
+            command_description: Style::default().fg(Color::DarkGray),
             command_selected: Style::default().fg(Color::White).bg(Color::Black),
 
             path_dir: Style::default().fg(Color::Blue),
             path_file: Style::default().fg(dark_yellow),
             path_selected: Style::default().fg(Color::White).bg(Color::Black),
 
-            log_info: Style::default().fg(Color::LightBlue),
-            log_debug: Style::default().fg(Color::LightGreen),
+            log_info: Style::default().fg(Color::Blue),
+            log_debug: Style::default().fg(Color::Green),
             log_warning: Style::default().fg(dark_yellow),
             log_error: Style::default().fg(Color::Red),
             log_message: Style::default().fg(Color::Black),

--- a/src/app/settings/edit_color_settings.rs
+++ b/src/app/settings/edit_color_settings.rs
@@ -11,7 +11,7 @@ macro_rules! EditColorSettings {(
         {
             pub fn edit_color_settings(&mut self, data: &std::collections::HashMap<String, ratatui::style::Style>) -> Result<(), String>
             {
-                for (key, value) in data.iter() 
+                for (key, value) in data.iter()
                 {
                     match key.as_str() {
                         $(

--- a/src/app/settings/edit_color_settings.rs
+++ b/src/app/settings/edit_color_settings.rs
@@ -1,0 +1,29 @@
+#[macro_export]
+macro_rules! EditColorSettings {(
+    $(#[$attr:meta])*
+    $pub:vis struct $color_settings:ident {
+        $(
+            $(#[$field_attr:meta])*
+            $field_pub:vis $field_name:ident: $field_type:ty,
+        )*
+    }) => {
+        impl $color_settings
+        {
+            pub fn edit_color_settings(&mut self, data: &std::collections::HashMap<String, ratatui::style::Style>) -> Result<(), String>
+            {
+                for (key, value) in data.iter() 
+                {
+                    match key.as_str() {
+                        $(
+                            stringify!($field_name) => self.$field_name = value.clone(),
+                        )*
+                        key => {
+                            return Err(format!("Unknown field: {}", key));
+                        }
+                    }
+                }
+                Ok(())
+            }
+        }
+    };
+}

--- a/src/app/settings/mod.rs
+++ b/src/app/settings/mod.rs
@@ -8,4 +8,6 @@ pub mod key_settings;
 pub mod register_key_settings_macro;
 #[macro_use]
 pub mod register_color_settings_macro;
+#[macro_use]
+pub mod edit_color_settings;
 pub mod settings_value;

--- a/src/app/settings/settings.rs
+++ b/src/app/settings/settings.rs
@@ -71,7 +71,7 @@ impl Settings {
                 if e.kind() != io::ErrorKind::NotFound {
                     Err(format!("Could not load settings: {}", e))
                 } else {
-                    let settings = Settings::default();
+                    let settings = Settings::empty(terminal_theme);
                     if path.is_some() {
                         settings
                             .save(path)
@@ -93,6 +93,15 @@ impl Settings {
         std::fs::create_dir_all(path.parent()?).ok()?;
         std::fs::write(&path, settings).ok()?;
         Some(())
+    }
+
+    pub fn empty(terminal_theme: Theme) -> Self {
+        Self {
+            color: ColorSettings::get_default_theme(terminal_theme),
+            key: KeySettings::default(),
+            app: AppSettings::default(),
+            custom: HashMap::new(),
+        }
     }
 }
 

--- a/src/app/settings/settings.rs
+++ b/src/app/settings/settings.rs
@@ -5,13 +5,16 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use ratatui::style::Style;
+use serde::de::Visitor;
+use crate::detect_theme::Theme;
+
 use super::{
     app_settings::AppSettings, color_settings::ColorSettings, key_settings::KeySettings,
     settings_value::SettingsValue,
 };
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Default)]
-#[serde(default)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct Settings {
     pub color: ColorSettings,
     pub key: KeySettings,
@@ -20,7 +23,7 @@ pub struct Settings {
 }
 
 impl Settings {
-    pub fn load(path: Option<&Path>) -> Result<Settings, io::Error> {
+    pub fn load(path: Option<&Path>, terminal_theme: Theme) -> Result<Settings, io::Error> {
         let path = match path {
             Some(path) => path.to_path_buf(),
             None => Self::get_default_settings_path().ok_or(io::Error::new(
@@ -41,7 +44,9 @@ impl Settings {
             Err(e) => return Err(e),
         };
 
-        Ok(match serde_json::from_str(&settings) {
+        let mut deserializer = serde_json::Deserializer::from_str(&settings);
+
+        Ok(match Settings::custom_deserialize(&mut deserializer, terminal_theme) {
             Ok(settings) => settings,
             Err(e) => {
                 return Err(io::Error::new(
@@ -57,17 +62,19 @@ impl Settings {
         Some(config.join("HexPatch").join("settings.json"))
     }
 
-    pub fn load_or_create(path: Option<&Path>) -> Result<Settings, String> {
-        match Self::load(path) {
+    pub fn load_or_create(path: Option<&Path>, terminal_theme: Theme) -> Result<Settings, String> {
+        match Self::load(path, terminal_theme) {
             Ok(settings) => Ok(settings),
             Err(e) => {
                 if e.kind() != io::ErrorKind::NotFound {
                     Err(format!("Could not load settings: {}", e))
                 } else {
                     let settings = Settings::default();
-                    settings
+                    if path.is_some() {
+                        settings
                         .save(path)
                         .ok_or(format!("Could not save default settings: {}", e))?;
+                    }
                     Ok(settings)
                 }
             }
@@ -87,6 +94,93 @@ impl Settings {
     }
 }
 
+struct SettingsVisitor {
+    theme: Theme,
+}
+
+impl<'de> Visitor<'de> for SettingsVisitor {
+    type Value = Settings;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a valid Settings struct")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::MapAccess<'de>, {
+        let mut color_settings: Option<HashMap<String, Style>> = None;
+        let mut key_settings: Option<KeySettings> = None;
+        let mut app_settings: Option<AppSettings> = None;
+        let mut custom_settings: Option<HashMap<String, SettingsValue>> = None;
+
+        while let Some(key) = map.next_key()? {
+            match key {
+                "color" => {
+                    if color_settings.is_some() {
+                        return Err(serde::de::Error::duplicate_field("color"));
+                    }
+                    color_settings = Some(map.next_value()?);
+                },
+                "key" => {
+                    if key_settings.is_some() {
+                        return Err(serde::de::Error::duplicate_field("key"));
+                    }
+                    key_settings = Some(map.next_value()?);
+                },
+                "app" => {
+                    if app_settings.is_some() {
+                        return Err(serde::de::Error::duplicate_field("app"));
+                    }
+                    app_settings = Some(map.next_value()?);
+                },
+                "custom" => {
+                    if custom_settings.is_some() {
+                        return Err(serde::de::Error::duplicate_field("custom"));
+                    }
+                    custom_settings = Some(map.next_value()?);
+                },
+                _ => {
+                    return Err(serde::de::Error::unknown_field(key, &["color", "key", "app", "custom"]));
+                },
+            }
+        }
+        let key_settings = key_settings.unwrap_or_default();
+        let app_settings = app_settings.unwrap_or_default();
+        let custom_settings = custom_settings.unwrap_or_default();
+        let color_settings = ColorSettings::from_map(&color_settings.unwrap_or_default(), &app_settings, self.theme).map_err(
+            |e| serde::de::Error::custom(e),
+        )?;
+
+        Ok(Self::Value {
+            color: color_settings,
+            key: key_settings,
+            app: app_settings,
+            custom: custom_settings,
+        })
+    }
+
+    
+}
+
+impl Settings {
+    fn custom_deserialize<'de, D>(deserializer: D, theme: Theme) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de> {
+        deserializer.deserialize_map(SettingsVisitor{theme})
+    }
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            color: ColorSettings::get_default_theme(Theme::Dark),
+            key: KeySettings::default(),
+            app: AppSettings::default(),
+            custom: HashMap::new(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -96,7 +190,7 @@ mod test {
 
     #[test]
     fn test_settings_load() {
-        let settings = Settings::load(Some(Path::new("test/default_settings.json")));
+        let settings = Settings::load(Some(Path::new("test/default_settings.json")), Theme::Dark);
         if let Err(e) = settings {
             panic!("Could not load settings: {}", e);
         }
@@ -105,7 +199,7 @@ mod test {
 
     #[test]
     fn test_settings_partial_load() {
-        let settings = Settings::load(Some(Path::new("test/partial_default_settings.json")));
+        let settings = Settings::load(Some(Path::new("test/partial_default_settings.json")), Theme::Dark);
         if let Err(e) = settings {
             panic!("Could not load settings: {}", e);
         }
@@ -114,7 +208,7 @@ mod test {
 
     #[test]
     fn test_settings_load_custom() {
-        let settings = Settings::load(Some(Path::new("test/custom_settings.json")));
+        let settings = Settings::load(Some(Path::new("test/custom_settings.json")), Theme::Dark);
         if let Err(e) = settings {
             panic!("Could not load settings: {}", e);
         }

--- a/src/app/text.rs
+++ b/src/app/text.rs
@@ -135,7 +135,7 @@ mod tests {
 
     #[test]
     fn test_bytes_to_styled_text() {
-        let color_settings = ColorSettings::default();
+        let color_settings = ColorSettings::get_default_dark_theme();
         let bytes = b"CAFEBABE";
         let block_size = 8;
         let blocks_per_row = 2;

--- a/src/detect_theme/mod.rs
+++ b/src/detect_theme/mod.rs
@@ -1,0 +1,410 @@
+/// The majority of the code in this file is from the `termbg` crate, it was copied 
+/// and modified to avoid a strange bug that was breaking the app on Windows.
+/// Refer to dalance/termbg#25 for more information.
+
+use crossterm::terminal;
+use is_terminal::IsTerminal;
+use std::env;
+use std::io::{self, Write};
+use std::time::{Duration, Instant};
+use thiserror::Error;
+#[cfg(target_os = "windows")]
+use winapi::um::wincon;
+
+/// Terminal
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Terminal {
+    Screen,
+    Tmux,
+    XtermCompatible,
+    Windows,
+    Emacs,
+    Unsupported
+}
+
+/// 16bit RGB color
+#[derive(Copy, Clone, Debug)]
+pub struct Rgb {
+    pub r: u16,
+    pub g: u16,
+    pub b: u16,
+}
+
+/// Background theme
+#[derive(Copy, Clone, Debug)]
+pub enum Theme {
+    Light,
+    Dark,
+}
+
+/// Error
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("io error")]
+    Io {
+        #[from]
+        source: io::Error,
+    },
+    #[error("parse error")]
+    Parse(String),
+    #[error("unsupported")]
+    Unsupported,
+}
+
+/// get detected termnial
+#[cfg(not(target_os = "windows"))]
+pub fn terminal() -> Terminal {
+    if env::var("INSIDE_EMACS").is_ok() {
+        return Terminal::Emacs;
+    }
+
+    if env::var("TMUX").is_ok() {
+        Terminal::Tmux
+    } else {
+        let is_screen = if let Ok(term) = env::var("TERM") {
+            term.starts_with("screen")
+        } else {
+            false
+        };
+        if is_screen {
+            Terminal::Screen
+        } else {
+            Terminal::XtermCompatible
+        }
+    }
+}
+
+/// get detected termnial
+#[cfg(target_os = "windows")]
+pub fn terminal() -> Terminal {
+    if let Ok(term_program) = env::var("TERM_PROGRAM") {
+        if term_program == "vscode" {
+            return Terminal::Unsupported;
+        }
+    }
+
+    if env::var("INSIDE_EMACS").is_ok() {
+        return Terminal::Emacs;
+    }
+
+    // Windows Terminal is Xterm-compatible
+    // https://github.com/microsoft/terminal/issues/3718
+    if env::var("WT_SESSION").is_ok() {
+        Terminal::Unsupported
+    } else {
+        Terminal::Windows
+    }
+}
+
+/// get background color by `RGB`
+#[cfg(not(target_os = "windows"))]
+pub fn rgb(timeout: Duration) -> Result<Rgb, Error> {
+    let term = terminal();
+    let rgb = match term {
+        Terminal::Emacs => Err(Error::Unsupported),
+        Terminal::Unsupported => Err(Error::Unsupported),
+        _ => from_xterm(term, timeout),
+    };
+    let fallback = from_env_colorfgbg();
+    if rgb.is_ok() {
+        rgb
+    } else if fallback.is_ok() {
+        fallback
+    } else {
+        rgb
+    }
+}
+
+/// get background color by `RGB`
+#[cfg(target_os = "windows")]
+pub fn rgb(timeout: Duration) -> Result<Rgb, Error> {
+    let term = terminal();
+    let rgb = match term {
+        Terminal::Emacs => Err(Error::Unsupported),
+        Terminal::XtermCompatible => from_xterm(term, timeout),
+        Terminal::Unsupported => Err(Error::Unsupported),
+        _ => from_winapi(),
+    };
+    let fallback = from_env_colorfgbg();
+    if rgb.is_ok() {
+        rgb
+    } else if fallback.is_ok() {
+        fallback
+    } else {
+        rgb
+    }
+}
+
+/// get background color by `RGB`
+#[cfg(not(target_os = "windows"))]
+pub fn latency(timeout: Duration) -> Result<Duration, Error> {
+    let term = terminal();
+    match term {
+        Terminal::Emacs => Ok(Duration::from_millis(0)),
+        Terminal::Unsupported => Ok(Duration::from_millis(0)),
+        _ => xterm_latency(timeout),
+    }
+}
+
+/// get background color by `RGB`
+#[cfg(target_os = "windows")]
+pub fn latency(timeout: Duration) -> Result<Duration, Error> {
+    let term = terminal();
+    match term {
+        Terminal::Emacs => Ok(Duration::from_millis(0)),
+        Terminal::XtermCompatible => xterm_latency(timeout),
+        Terminal::Unsupported => Ok(Duration::from_millis(0)),
+        _ => Ok(Duration::from_millis(0)),
+    }
+}
+
+/// get background color by `Theme`
+pub fn theme(timeout: Duration) -> Result<Theme, Error> {
+    let rgb = rgb(timeout)?;
+
+    // ITU-R BT.601
+    let y = rgb.r as f64 * 0.299 + rgb.g as f64 * 0.587 + rgb.b as f64 * 0.114;
+
+    if y > 32768.0 {
+        Ok(Theme::Light)
+    } else {
+        Ok(Theme::Dark)
+    }
+}
+
+fn from_xterm(term: Terminal, timeout: Duration) -> Result<Rgb, Error> {
+    if !std::io::stdin().is_terminal()
+        || !std::io::stdout().is_terminal()
+        || !std::io::stderr().is_terminal()
+    {
+        // Not a terminal, so don't try to read the current background color.
+        return Err(Error::Unsupported);
+    }
+
+    // Query by XTerm control sequence
+    let query = if term == Terminal::Tmux {
+        "\x1bPtmux;\x1b\x1b]11;?\x07\x1b\\\x03"
+    } else if term == Terminal::Screen {
+        "\x1bP\x1b]11;?\x07\x1b\\\x03"
+    } else {
+        "\x1b]11;?\x1b\\"
+    };
+
+    let mut stderr = io::stderr();
+    terminal::enable_raw_mode()?;
+    write!(stderr, "{}", query)?;
+    stderr.flush()?;
+
+    let buffer = async_std::task::block_on(async_std::io::timeout(timeout, async {
+        use async_std::io::ReadExt;
+        let mut buffer = Vec::new();
+        let mut stdin = async_std::io::stdin();
+        let mut buf = [0; 1];
+        let mut start = false;
+        loop {
+            let _ = stdin.read_exact(&mut buf).await?;
+            // response terminated by BEL(0x7)
+            if start && (buf[0] == 0x7) {
+                break;
+            }
+            // response terminated by ST(0x1b 0x5c)
+            if start && (buf[0] == 0x1b) {
+                // consume last 0x5c
+                let _ = stdin.read_exact(&mut buf).await?;
+                debug_assert_eq!(buf[0], 0x5c);
+                break;
+            }
+            if start {
+                buffer.push(buf[0]);
+            }
+            if buf[0] == b':' {
+                start = true;
+            }
+        }
+        Ok(buffer)
+    }));
+
+    terminal::disable_raw_mode()?;
+
+    // Should return by error after disable_raw_mode
+    let buffer = buffer?;
+
+    let s = String::from_utf8_lossy(&buffer);
+    let (r, g, b) = decode_x11_color(&*s)?;
+    Ok(Rgb { r, g, b })
+}
+
+fn from_env_colorfgbg() -> Result<Rgb, Error> {
+    let var = env::var("COLORFGBG").map_err(|_| Error::Unsupported)?;
+    let fgbg: Vec<_> = var.split(";").collect();
+    let bg = fgbg.get(1).ok_or(Error::Unsupported)?;
+    let bg = u8::from_str_radix(bg, 10).map_err(|_| Error::Parse(String::from(var)))?;
+
+    // rxvt default color table
+    let (r, g, b) = match bg {
+        // black
+        0 => (0, 0, 0),
+        // red
+        1 => (205, 0, 0),
+        // green
+        2 => (0, 205, 0),
+        // yellow
+        3 => (205, 205, 0),
+        // blue
+        4 => (0, 0, 238),
+        // magenta
+        5 => (205, 0, 205),
+
+        // cyan
+        6 => (0, 205, 205),
+        // white
+        7 => (229, 229, 229),
+        // bright black
+        8 => (127, 127, 127),
+        // bright red
+        9 => (255, 0, 0),
+        // bright green
+        10 => (0, 255, 0),
+        // bright yellow
+        11 => (255, 255, 0),
+        // bright blue
+        12 => (92, 92, 255),
+        // bright magenta
+        13 => (255, 0, 255),
+        // bright cyan
+        14 => (0, 255, 255),
+
+        // bright white
+        15 => (255, 255, 255),
+        _ => (0, 0, 0),
+    };
+
+    Ok(Rgb {
+        r: r * 256,
+        g: g * 256,
+        b: b * 256,
+    })
+}
+
+fn xterm_latency(timeout: Duration) -> Result<Duration, Error> {
+    // Query by XTerm control sequence
+    let query = "\x1b[5n";
+
+    let mut stderr = io::stderr();
+    terminal::enable_raw_mode()?;
+    write!(stderr, "{}", query)?;
+    stderr.flush()?;
+
+    let start = Instant::now();
+
+    let ret = async_std::task::block_on(async_std::io::timeout(timeout, async {
+        use async_std::io::ReadExt;
+        let mut stdin = async_std::io::stdin();
+        let mut buf = [0; 1];
+        loop {
+            let _ = stdin.read_exact(&mut buf).await?;
+            // response terminated by 'n'
+            if buf[0] == b'n' {
+                break;
+            }
+        }
+        Ok(())
+    }));
+
+    let end = start.elapsed();
+
+    terminal::disable_raw_mode()?;
+
+    let _ = ret?;
+
+    Ok(end)
+}
+
+fn decode_x11_color(s: &str) -> Result<(u16, u16, u16), Error> {
+    fn decode_hex(s: &str) -> Result<u16, Error> {
+        let len = s.len() as u32;
+        let mut ret = u16::from_str_radix(s, 16).map_err(|_| Error::Parse(String::from(s)))?;
+        ret = ret << ((4 - len) * 4);
+        Ok(ret)
+    }
+
+    let rgb: Vec<_> = s.split("/").collect();
+
+    let r = rgb.get(0).ok_or_else(|| Error::Parse(String::from(s)))?;
+    let g = rgb.get(1).ok_or_else(|| Error::Parse(String::from(s)))?;
+    let b = rgb.get(2).ok_or_else(|| Error::Parse(String::from(s)))?;
+    let r = decode_hex(r)?;
+    let g = decode_hex(g)?;
+    let b = decode_hex(b)?;
+
+    Ok((r, g, b))
+}
+
+#[cfg(target_os = "windows")]
+fn from_winapi() -> Result<Rgb, Error> {
+    let info = unsafe {
+        let handle = winapi::um::processenv::GetStdHandle(winapi::um::winbase::STD_OUTPUT_HANDLE);
+        let mut info: wincon::CONSOLE_SCREEN_BUFFER_INFO = Default::default();
+        wincon::GetConsoleScreenBufferInfo(handle, &mut info);
+        info
+    };
+
+    let r = (wincon::BACKGROUND_RED & info.wAttributes) != 0;
+    let g = (wincon::BACKGROUND_GREEN & info.wAttributes) != 0;
+    let b = (wincon::BACKGROUND_BLUE & info.wAttributes) != 0;
+    let i = (wincon::BACKGROUND_INTENSITY & info.wAttributes) != 0;
+
+    let r: u8 = r as u8;
+    let g: u8 = g as u8;
+    let b: u8 = b as u8;
+    let i: u8 = i as u8;
+
+    let (r, g, b) = match (r, g, b, i) {
+        (0, 0, 0, 0) => (0, 0, 0),
+        (1, 0, 0, 0) => (128, 0, 0),
+        (0, 1, 0, 0) => (0, 128, 0),
+        (1, 1, 0, 0) => (128, 128, 0),
+        (0, 0, 1, 0) => (0, 0, 128),
+        (1, 0, 1, 0) => (128, 0, 128),
+        (0, 1, 1, 0) => (0, 128, 128),
+        (1, 1, 1, 0) => (192, 192, 192),
+        (0, 0, 0, 1) => (128, 128, 128),
+        (1, 0, 0, 1) => (255, 0, 0),
+        (0, 1, 0, 1) => (0, 255, 0),
+        (1, 1, 0, 1) => (255, 255, 0),
+        (0, 0, 1, 1) => (0, 0, 255),
+        (1, 0, 1, 1) => (255, 0, 255),
+        (0, 1, 1, 1) => (0, 255, 255),
+        (1, 1, 1, 1) => (255, 255, 255),
+        _ => unreachable!(),
+    };
+
+    Ok(Rgb {
+        r: r * 256,
+        g: g * 256,
+        b: b * 256,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_x11_color() {
+        let s = "0000/0000/0000";
+        assert_eq!((0, 0, 0), decode_x11_color(s).unwrap());
+
+        let s = "1111/2222/3333";
+        assert_eq!((0x1111, 0x2222, 0x3333), decode_x11_color(s).unwrap());
+
+        let s = "111/222/333";
+        assert_eq!((0x1110, 0x2220, 0x3330), decode_x11_color(s).unwrap());
+
+        let s = "11/22/33";
+        assert_eq!((0x1100, 0x2200, 0x3300), decode_x11_color(s).unwrap());
+
+        let s = "1/2/3";
+        assert_eq!((0x1000, 0x2000, 0x3000), decode_x11_color(s).unwrap());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ its documentation is not complete.
 pub mod app;
 pub mod args;
 pub mod asm;
+pub mod detect_theme;
 pub mod fuzzer;
 pub mod headers;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,18 @@
+use std::time::Duration;
+
 use clap::Parser;
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use hex_patch::{app::App, args};
+use hex_patch::{app::App, args, detect_theme};
 use ratatui::backend::CrosstermBackend;
 
 fn main() {
     let args = args::Args::parse();
+    let theme = detect_theme::theme(Duration::from_secs(1))
+        .unwrap_or(detect_theme::Theme::Dark);
 
     enable_raw_mode().expect("Failed to enable raw mode");
     let mut stdout = std::io::stdout();
@@ -18,7 +22,7 @@ fn main() {
     let mut terminal = ratatui::Terminal::new(backend).expect("Failed to create terminal");
 
     terminal.clear().expect("Failed to clear terminal");
-    let mut app = App::new(args, &mut terminal).expect("Failed to create app");
+    let mut app = App::new(args, &mut terminal, theme).expect("Failed to create app");
     let res = app.run(&mut terminal);
     terminal.clear().expect("Failed to clear terminal");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,7 @@ use ratatui::backend::CrosstermBackend;
 
 fn main() {
     let args = args::Args::parse();
-    let theme = detect_theme::theme(Duration::from_secs(1))
-        .unwrap_or(detect_theme::Theme::Dark);
+    let theme = detect_theme::theme(Duration::from_secs(1)).unwrap_or(detect_theme::Theme::Dark);
 
     enable_raw_mode().expect("Failed to enable raw mode");
     let mut stdout = std::io::stdout();

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use ratatui::backend::CrosstermBackend;
 
 fn main() {
     let args = args::Args::parse();
-    let theme = detect_theme::theme(Duration::from_secs(1)).unwrap_or(detect_theme::Theme::Dark);
+    let theme = detect_theme::theme(Duration::from_secs(1));
 
     enable_raw_mode().expect("Failed to enable raw mode");
     let mut stdout = std::io::stdout();

--- a/test/default_settings.json
+++ b/test/default_settings.json
@@ -189,7 +189,7 @@
       "add_modifier": "",
       "sub_modifier": ""
     },
-    "hep_description": {
+    "help_description": {
       "fg": "Gray",
       "bg": null,
       "underline_color": null,

--- a/test/light_theme_settings.json
+++ b/test/light_theme_settings.json
@@ -1,0 +1,5 @@
+{
+    "app": {
+        "theme": "light"
+    }
+}

--- a/test/partial_default_settings.json
+++ b/test/partial_default_settings.json
@@ -189,7 +189,7 @@
       "add_modifier": "",
       "sub_modifier": ""
     },
-    "hep_description": {
+    "help_description": {
       "fg": "Gray",
       "bg": null,
       "underline_color": null,


### PR DESCRIPTION
**References:**
#108 

**Description:**
Added a light theme (too see the change you might have to delete the current settings.json file or at least the `"color"` object), changed how the settings are deserialized to allow for a smoother upgrade to newer versions, fixed a typo in the color settings that made useless a specific setting: `"help_description"` was called `"hep_description"`. The old key should be removed or renamed in your settings.json.
