### PR TITLE
Now you can load and save comments

### DIFF
--- a/src/app/commands/command_info.rs
+++ b/src/app/commands/command_info.rs
@@ -23,6 +23,7 @@ impl CommandInfo {
             CommandInfo::new("xquit", "Save and quit the program."),
             CommandInfo::new("save", "Save the current file."),
             CommandInfo::new("saveas", "Save the current file as a new file."),
+            CommandInfo::new("csave", "Save the comments."),
             CommandInfo::new("help", "Display the help page."),
             CommandInfo::new("open", "Open a file."),
             CommandInfo::new("log", "Open the log."),

--- a/src/app/commands/run_command.rs
+++ b/src/app/commands/run_command.rs
@@ -49,6 +49,9 @@ impl App {
             "saveas" => {
                 self.request_popup_save_as();
             }
+            "csave" => {
+                self.save_comments(None);
+            }
             "help" => {
                 self.request_popup_help();
             }

--- a/src/app/comments.rs
+++ b/src/app/comments.rs
@@ -1,25 +1,32 @@
 use std::collections::{hash_map::Iter, HashMap};
 
-use super::App;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+use super::{log::NotificationLevel, App};
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Comments {
     comments: HashMap<u64, String>,
+    #[serde(skip)]
+    dirty: bool,
 }
 
 impl Comments {
     pub fn new() -> Self {
         Self {
             comments: HashMap::new(),
+            dirty: false,
         }
     }
 
     pub fn remove(&mut self, address: &u64) {
         self.comments.remove(address);
+        self.dirty = true;
     }
 
     pub fn insert(&mut self, address: u64, comment: String) {
         self.comments.insert(address, comment);
+        self.dirty = true;
     }
 
     pub fn iter(&self) -> Iter<'_, u64, String> {
@@ -30,10 +37,6 @@ impl Comments {
         self.comments.get(address)
     }
 
-    pub fn get_mut(&mut self, address: &u64) -> Option<&mut String> {
-        self.comments.get_mut(address)
-    }
-
     pub fn len(&self) -> usize {
         self.comments.len()
     }
@@ -42,8 +45,27 @@ impl Comments {
         self.comments.is_empty()
     }
 
-    pub fn clear(&mut self) {
-        self.comments.clear();
+    pub fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+
+    pub fn reset_dirty(&mut self) {
+        self.dirty = false;
+    }
+
+    pub fn check_max_address(&mut self, max_address: u64) {
+        let mut comments_removed = false;
+        self.comments.retain(|address, _| {
+            if *address > max_address {
+                comments_removed = true;
+                false
+            } else {
+                true
+            }
+        });
+        if comments_removed {
+            self.dirty = true;
+        }
     }
 }
 
@@ -69,5 +91,116 @@ impl App {
             .collect();
         comments.sort_by_key(|(_, symbol)| symbol.len());
         comments
+    }
+
+    pub(super) fn get_comments_path(&self) -> String {
+        let path = self.filesystem.pwd();
+        path.to_string() + ".hp-data.json"
+    }
+
+    /// If comments_path is None, it will use the default path calculated by get_comments_path.
+    pub(super) fn save_comments(&mut self, comments_path: Option<String>) {
+        if self.comments.is_dirty() {
+            let comments_str = serde_json::to_string_pretty(&self.comments).unwrap();
+            let comments_path = comments_path.unwrap_or(self.get_comments_path());
+            if let Err(e) = self.filesystem.create(&comments_path) {
+                self.log(
+                    NotificationLevel::Error,
+                    &format!("Failed to create comments: {}", e),
+                );
+                return;
+            }
+            if let Err(e) = self
+                .filesystem
+                .write(&comments_path, comments_str.as_bytes())
+            {
+                self.log(
+                    NotificationLevel::Error,
+                    &format!("Failed to write comments: {}", e),
+                );
+                return;
+            }
+            self.log(NotificationLevel::Info, "Comments saved.");
+            self.comments.reset_dirty();
+        }
+    }
+
+    /// If comments_path is None, it will use the default path calculated by get_comments_path.
+    pub(super) fn load_comments(&mut self, comments_path: Option<String>) {
+        let comments_path = comments_path.unwrap_or(self.get_comments_path());
+        match self.filesystem.read(&comments_path) {
+            Ok(comments_data) => match serde_json::from_slice::<Comments>(&comments_data) {
+                Ok(comments) => {
+                    self.comments = comments;
+                    self.comments
+                        .check_max_address(self.data.bytes().len() as u64);
+                    self.log(NotificationLevel::Info, "Comments loaded.");
+                }
+                Err(e) => {
+                    self.log(
+                        NotificationLevel::Error,
+                        &format!("Failed to parse comments: {}", e),
+                    );
+                }
+            },
+            Err(e) => {
+                // This is in debug because the file may not exist.
+                self.log(
+                    NotificationLevel::Debug,
+                    &format!("Failed to read comments: {}", e),
+                );
+                self.comments = Comments::new();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_and_remove() {
+        let mut comments = Comments::new();
+        comments.insert(0x1000, "comment_1".to_string());
+        assert!(comments.is_dirty());
+        comments.insert(0x2000, "comment_2".to_string());
+        comments.insert(0x3000, "comment_3".to_string());
+        comments.reset_dirty();
+        assert_eq!(comments.len(), 3);
+        assert_eq!(comments.get(&0x1000), Some(&"comment_1".to_string()));
+        assert_eq!(comments.get(&0x2000), Some(&"comment_2".to_string()));
+        assert_eq!(comments.get(&0x3000), Some(&"comment_3".to_string()));
+        assert!(!comments.is_dirty());
+        comments.remove(&0x2000);
+        assert!(comments.is_dirty());
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments.get(&0x1000), Some(&"comment_1".to_string()));
+        assert_eq!(comments.get(&0x2000), None);
+        assert_eq!(comments.get(&0x3000), Some(&"comment_3".to_string()));
+        comments.check_max_address(0x2000);
+        assert_eq!(comments.len(), 1);
+        assert_eq!(comments.get(&0x1000), Some(&"comment_1".to_string()));
+        assert_eq!(comments.get(&0x2000), None);
+        assert_eq!(comments.get(&0x3000), None);
+    }
+
+    #[test]
+    fn save_and_load() {
+        let mut app = App::mockup(vec![0x90; 0x100]);
+        let tmp_comments = tempfile::NamedTempFile::new().unwrap();
+        let comments_path = tmp_comments.path().to_str().unwrap().to_string();
+        app.comments.insert(0x10, "comment_1".to_string());
+        app.comments.insert(0x20, "comment_2".to_string());
+        app.comments.insert(0x30, "comment_3".to_string());
+        app.save_comments(Some(comments_path.clone()));
+        assert!(!app.comments.is_dirty());
+        assert!(app.logger.get_notification_level() < NotificationLevel::Warning);
+        app.comments = Comments::new();
+        app.load_comments(Some(comments_path));
+        assert_eq!(app.comments.len(), 3);
+        assert_eq!(app.comments.get(&0x10), Some(&"comment_1".to_string()));
+        assert_eq!(app.comments.get(&0x20), Some(&"comment_2".to_string()));
+        assert_eq!(app.comments.get(&0x30), Some(&"comment_3".to_string()));
     }
 }

--- a/src/app/files/files.rs
+++ b/src/app/files/files.rs
@@ -5,8 +5,8 @@ use ratatui::{backend::Backend, Terminal};
 
 use crate::{
     app::{
-        comments::Comments, data::Data, info_mode::InfoMode, log::NotificationLevel,
-        popup::popup_state::PopupState, App,
+        data::Data, info_mode::InfoMode, log::NotificationLevel, popup::popup_state::PopupState,
+        App,
     },
     get_app_context,
     headers::Header,
@@ -189,8 +189,8 @@ impl App {
             self.filesystem.read(self.filesystem.pwd())?,
             self.settings.app.history_limit,
         );
-        // TODO: You might want to load the comments from file here
-        self.comments = Comments::default();
+
+        self.load_comments(None);
 
         Self::print_loading_status(&self.settings.color, "Decoding binary data...", terminal)?;
 

--- a/src/app/plugins/plugin.rs
+++ b/src/app/plugins/plugin.rs
@@ -591,19 +591,18 @@ mod test {
         let event = Event::Open;
         plugin.handle_with_error(event, &mut app_context).unwrap();
 
-        let messages = app_context.logger.iter().collect::<Vec<_>>();
-        assert_eq!(messages.len(), 6);
-        assert_eq!(messages[3].message, 64.to_string(), "Default bitness is 64");
-        assert_eq!(
-            messages[4].message,
-            format!("{:?}", Architecture::Unknown),
-            "Default architecture is Unknown"
-        );
-        assert_eq!(
-            messages[5].message,
-            0.to_string(),
-            "Default entry point is 0"
-        );
+        assert!(app_context
+            .logger
+            .iter()
+            .any(|message| { message.message == 64.to_string() }));
+        assert!(app_context
+            .logger
+            .iter()
+            .any(|message| { message.message == format!("{:?}", Architecture::Unknown) }),);
+        assert!(app_context
+            .logger
+            .iter()
+            .any(|message| { message.message == 0.to_string() }),);
     }
 
     #[test]


### PR DESCRIPTION
**References:**
#122

**Description:**
Now you can save comments to a file with the command "csave" and they will be loaded automatically when you open hexpatch, the file will be called <binary_file>.hp-data.json
