### PR TITLE
Added support for EBPF deasm and patching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,6 +1511,7 @@ dependencies = [
  "object",
  "pdb",
  "ratatui",
+ "rbpf",
  "regex",
  "russh",
  "russh-sftp",
@@ -2830,6 +2841,19 @@ dependencies = [
  "time",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "rbpf"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7fd1b4fdf96615efe17cfd01307737988fd17ece498e36f34d30e98726027d"
+dependencies = [
+ "byteorder",
+ "combine",
+ "hashbrown 0.16.1",
+ "libc",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ termbg = "0.6.2"
 rust-i18n = "4.0.0"
 sys-locale = "0.3.2"
 const-str = "1.1.0"
+rbpf = "0.4.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/src/asm/assembler.rs
+++ b/src/asm/assembler.rs
@@ -1,6 +1,8 @@
 use std::error::Error;
 
+use crate::headers::encoder::Encoder;
 use crate::headers::Header;
+use rbpf::assembler;
 
 pub fn assemble(
     asm: &str,
@@ -11,8 +13,17 @@ pub fn assemble(
         .get_encoder()
         .map_err(|e| t!("errors.create_encoder", e = e))?;
 
-    let out = encoder
-        .asm(asm.to_string(), starting_virtual_address)
-        .map_err(|e| t!("errors.assemble", e = e))?;
-    Ok(out.bytes)
+    let out: Vec<u8> = match encoder {
+        Encoder::Keystone(keystone) => {
+            keystone.asm(asm.to_string(),starting_virtual_address)
+                .map_err(|e| t!("errors.assemble",e=e))?
+                .bytes
+        },
+        Encoder::EBPF => {
+            assembler::assemble(asm)
+                .map_err(|e| t!("errors.assemble",e=e))?
+        }
+    };
+    
+    Ok(out)
 }

--- a/src/asm/assembler.rs
+++ b/src/asm/assembler.rs
@@ -15,15 +15,13 @@ pub fn assemble(
 
     let out: Vec<u8> = match encoder {
         Encoder::Keystone(keystone) => {
-            keystone.asm(asm.to_string(),starting_virtual_address)
-                .map_err(|e| t!("errors.assemble",e=e))?
+            keystone
+                .asm(asm.to_string(), starting_virtual_address)
+                .map_err(|e| t!("errors.assemble", e = e))?
                 .bytes
-        },
-        Encoder::EBPF => {
-            assembler::assemble(asm)
-                .map_err(|e| t!("errors.assemble",e=e))?
         }
+        Encoder::EBPF => assembler::assemble(asm).map_err(|e| t!("errors.assemble", e = e))?,
     };
-    
+
     Ok(out)
 }

--- a/src/headers/encoder.rs
+++ b/src/headers/encoder.rs
@@ -1,7 +1,6 @@
 use hexpatch_keystone::Keystone;
 
-
-pub enum Encoder{
+pub enum Encoder {
     Keystone(Keystone),
     EBPF,
 }

--- a/src/headers/encoder.rs
+++ b/src/headers/encoder.rs
@@ -1,0 +1,7 @@
+use hexpatch_keystone::Keystone;
+
+
+pub enum Encoder{
+    Keystone(Keystone),
+    EBPF,
+}

--- a/src/headers/header.rs
+++ b/src/headers/header.rs
@@ -201,44 +201,33 @@ impl Header {
 
     pub(super) fn get_encoder_for_arch(architecture: &Architecture) -> Result<Encoder, Error> {
         match architecture {
-            Architecture::Aarch64 => Keystone::new(Arch::ARM64, Mode::LITTLE_ENDIAN)
-                .map(|keystone| Encoder::Keystone(keystone)),
-            Architecture::Aarch64_Ilp32 => Keystone::new(Arch::ARM64, Mode::LITTLE_ENDIAN)
-                .map(|keystone| Encoder::Keystone(keystone)),
-            Architecture::Arm => {
-                Keystone::new(Arch::ARM, Mode::ARM).map(|keystone| Encoder::Keystone(keystone))
+            Architecture::Aarch64 => {
+                Keystone::new(Arch::ARM64, Mode::LITTLE_ENDIAN).map(Encoder::Keystone)
             }
-            Architecture::I386 => {
-                Keystone::new(Arch::X86, Mode::MODE_32).map(|keystone| Encoder::Keystone(keystone))
+            Architecture::Aarch64_Ilp32 => {
+                Keystone::new(Arch::ARM64, Mode::LITTLE_ENDIAN).map(Encoder::Keystone)
             }
-            Architecture::X86_64 => {
-                Keystone::new(Arch::X86, Mode::MODE_64).map(|keystone| Encoder::Keystone(keystone))
-            }
+            Architecture::Arm => Keystone::new(Arch::ARM, Mode::ARM).map(Encoder::Keystone),
+            Architecture::I386 => Keystone::new(Arch::X86, Mode::MODE_32).map(Encoder::Keystone),
+            Architecture::X86_64 => Keystone::new(Arch::X86, Mode::MODE_64).map(Encoder::Keystone),
             Architecture::X86_64_X32 => {
-                Keystone::new(Arch::X86, Mode::MODE_32).map(|keystone| Encoder::Keystone(keystone))
+                Keystone::new(Arch::X86, Mode::MODE_32).map(Encoder::Keystone)
             }
-            Architecture::Hexagon => Keystone::new(Arch::HEXAGON, Mode::MODE_32)
-                .map(|keystone| Encoder::Keystone(keystone)),
-            Architecture::Mips => {
-                Keystone::new(Arch::MIPS, Mode::MIPS32).map(|keystone| Encoder::Keystone(keystone))
+            Architecture::Hexagon => {
+                Keystone::new(Arch::HEXAGON, Mode::MODE_32).map(Encoder::Keystone)
             }
-            Architecture::Mips64 => {
-                Keystone::new(Arch::MIPS, Mode::MIPS64).map(|keystone| Encoder::Keystone(keystone))
+            Architecture::Mips => Keystone::new(Arch::MIPS, Mode::MIPS32).map(Encoder::Keystone),
+            Architecture::Mips64 => Keystone::new(Arch::MIPS, Mode::MIPS64).map(Encoder::Keystone),
+            Architecture::PowerPc => Keystone::new(Arch::PPC, Mode::PPC32).map(Encoder::Keystone),
+            Architecture::PowerPc64 => Keystone::new(Arch::PPC, Mode::PPC64).map(Encoder::Keystone),
+            Architecture::S390x => {
+                Keystone::new(Arch::SYSTEMZ, Mode::MODE_32).map(Encoder::Keystone)
             }
-            Architecture::PowerPc => {
-                Keystone::new(Arch::PPC, Mode::PPC32).map(|keystone| Encoder::Keystone(keystone))
+            Architecture::Sparc64 => {
+                Keystone::new(Arch::SPARC, Mode::SPARC64).map(Encoder::Keystone)
             }
-            Architecture::PowerPc64 => {
-                Keystone::new(Arch::PPC, Mode::PPC64).map(|keystone| Encoder::Keystone(keystone))
-            }
-            Architecture::S390x => Keystone::new(Arch::SYSTEMZ, Mode::MODE_32)
-                .map(|keystone| Encoder::Keystone(keystone)),
-            Architecture::Sparc64 => Keystone::new(Arch::SPARC, Mode::SPARC64)
-                .map(|keystone| Encoder::Keystone(keystone)),
             Architecture::Bpf => Ok(Encoder::EBPF),
-            _ => {
-                Keystone::new(Arch::X86, Mode::MODE_64).map(|keystone| Encoder::Keystone(keystone))
-            }
+            _ => Keystone::new(Arch::X86, Mode::MODE_64).map(Encoder::Keystone),
         }
     }
 
@@ -261,9 +250,7 @@ impl Header {
         match self {
             Header::GenericHeader(header) => Self::get_encoder_for_arch(&header.architecture),
             Header::CustomHeader(header) => Self::get_encoder_for_arch(&header.architecture),
-            Header::None => {
-                Keystone::new(Arch::X86, Mode::MODE_64).map(|keystone| Encoder::Keystone(keystone))
-            }
+            Header::None => Keystone::new(Arch::X86, Mode::MODE_64).map(Encoder::Keystone),
         }
     }
 }

--- a/src/headers/header.rs
+++ b/src/headers/header.rs
@@ -201,21 +201,44 @@ impl Header {
 
     pub(super) fn get_encoder_for_arch(architecture: &Architecture) -> Result<Encoder, Error> {
         match architecture {
-            Architecture::Aarch64 => Keystone::new(Arch::ARM64, Mode::LITTLE_ENDIAN).map(|keystone| Encoder::Keystone(keystone)),
-            Architecture::Aarch64_Ilp32 => Keystone::new(Arch::ARM64, Mode::LITTLE_ENDIAN).map(|keystone| Encoder::Keystone(keystone)),
-            Architecture::Arm => Keystone::new(Arch::ARM, Mode::ARM).map(|keystone| Encoder::Keystone(keystone)),
-            Architecture::I386 => Keystone::new(Arch::X86, Mode::MODE_32).map(|keystone| Encoder::Keystone(keystone)),
-            Architecture::X86_64 => Keystone::new(Arch::X86, Mode::MODE_64).map(|keystone| Encoder::Keystone(keystone)),
-            Architecture::X86_64_X32 => Keystone::new(Arch::X86, Mode::MODE_32).map(|keystone| Encoder::Keystone(keystone)),
-            Architecture::Hexagon => Keystone::new(Arch::HEXAGON, Mode::MODE_32).map(|keystone| Encoder::Keystone(keystone)),
-            Architecture::Mips => Keystone::new(Arch::MIPS, Mode::MIPS32).map(|keystone| Encoder::Keystone(keystone)),
-            Architecture::Mips64 => Keystone::new(Arch::MIPS, Mode::MIPS64).map(|keystone| Encoder::Keystone(keystone)),
-            Architecture::PowerPc => Keystone::new(Arch::PPC, Mode::PPC32).map(|keystone| Encoder::Keystone(keystone)),
-            Architecture::PowerPc64 => Keystone::new(Arch::PPC, Mode::PPC64).map(|keystone| Encoder::Keystone(keystone)),
-            Architecture::S390x => Keystone::new(Arch::SYSTEMZ, Mode::MODE_32).map(|keystone| Encoder::Keystone(keystone)),
-            Architecture::Sparc64 => Keystone::new(Arch::SPARC, Mode::SPARC64).map(|keystone| Encoder::Keystone(keystone)),
+            Architecture::Aarch64 => Keystone::new(Arch::ARM64, Mode::LITTLE_ENDIAN)
+                .map(|keystone| Encoder::Keystone(keystone)),
+            Architecture::Aarch64_Ilp32 => Keystone::new(Arch::ARM64, Mode::LITTLE_ENDIAN)
+                .map(|keystone| Encoder::Keystone(keystone)),
+            Architecture::Arm => {
+                Keystone::new(Arch::ARM, Mode::ARM).map(|keystone| Encoder::Keystone(keystone))
+            }
+            Architecture::I386 => {
+                Keystone::new(Arch::X86, Mode::MODE_32).map(|keystone| Encoder::Keystone(keystone))
+            }
+            Architecture::X86_64 => {
+                Keystone::new(Arch::X86, Mode::MODE_64).map(|keystone| Encoder::Keystone(keystone))
+            }
+            Architecture::X86_64_X32 => {
+                Keystone::new(Arch::X86, Mode::MODE_32).map(|keystone| Encoder::Keystone(keystone))
+            }
+            Architecture::Hexagon => Keystone::new(Arch::HEXAGON, Mode::MODE_32)
+                .map(|keystone| Encoder::Keystone(keystone)),
+            Architecture::Mips => {
+                Keystone::new(Arch::MIPS, Mode::MIPS32).map(|keystone| Encoder::Keystone(keystone))
+            }
+            Architecture::Mips64 => {
+                Keystone::new(Arch::MIPS, Mode::MIPS64).map(|keystone| Encoder::Keystone(keystone))
+            }
+            Architecture::PowerPc => {
+                Keystone::new(Arch::PPC, Mode::PPC32).map(|keystone| Encoder::Keystone(keystone))
+            }
+            Architecture::PowerPc64 => {
+                Keystone::new(Arch::PPC, Mode::PPC64).map(|keystone| Encoder::Keystone(keystone))
+            }
+            Architecture::S390x => Keystone::new(Arch::SYSTEMZ, Mode::MODE_32)
+                .map(|keystone| Encoder::Keystone(keystone)),
+            Architecture::Sparc64 => Keystone::new(Arch::SPARC, Mode::SPARC64)
+                .map(|keystone| Encoder::Keystone(keystone)),
             Architecture::Bpf => Ok(Encoder::EBPF),
-            _ => Keystone::new(Arch::X86, Mode::MODE_64).map(|keystone| Encoder::Keystone(keystone)),
+            _ => {
+                Keystone::new(Arch::X86, Mode::MODE_64).map(|keystone| Encoder::Keystone(keystone))
+            }
         }
     }
 
@@ -238,7 +261,9 @@ impl Header {
         match self {
             Header::GenericHeader(header) => Self::get_encoder_for_arch(&header.architecture),
             Header::CustomHeader(header) => Self::get_encoder_for_arch(&header.architecture),
-            Header::None => Keystone::new(Arch::X86, Mode::MODE_64).map(|keystone| Encoder::Keystone(keystone)),
+            Header::None => {
+                Keystone::new(Arch::X86, Mode::MODE_64).map(|keystone| Encoder::Keystone(keystone))
+            }
         }
     }
 }

--- a/src/headers/header.rs
+++ b/src/headers/header.rs
@@ -8,7 +8,7 @@ use hexpatch_keystone::{Arch, Error, Keystone, Mode};
 use mlua::UserData;
 use object::{Architecture, Endianness};
 
-use crate::app::files::filesystem::FileSystem;
+use crate::{app::files::filesystem::FileSystem, headers::encoder::Encoder};
 
 use super::{
     bitness::Bitness, custom_header::CustomHeader, generic::GenericHeader, section::Section,
@@ -188,6 +188,10 @@ impl Header {
                 .sparc()
                 .mode(arch::sparc::ArchMode::V9)
                 .build(),
+            Architecture::Bpf => Capstone::new()
+                .bpf()
+                .mode(arch::bpf::ArchMode::Ebpf)
+                .build(),
             _ => Capstone::new()
                 .x86()
                 .mode(arch::x86::ArchMode::Mode64)
@@ -195,22 +199,23 @@ impl Header {
         }
     }
 
-    pub(super) fn get_encoder_for_arch(architecture: &Architecture) -> Result<Keystone, Error> {
+    pub(super) fn get_encoder_for_arch(architecture: &Architecture) -> Result<Encoder, Error> {
         match architecture {
-            Architecture::Aarch64 => Keystone::new(Arch::ARM64, Mode::LITTLE_ENDIAN),
-            Architecture::Aarch64_Ilp32 => Keystone::new(Arch::ARM64, Mode::LITTLE_ENDIAN),
-            Architecture::Arm => Keystone::new(Arch::ARM, Mode::ARM),
-            Architecture::I386 => Keystone::new(Arch::X86, Mode::MODE_32),
-            Architecture::X86_64 => Keystone::new(Arch::X86, Mode::MODE_64),
-            Architecture::X86_64_X32 => Keystone::new(Arch::X86, Mode::MODE_32),
-            Architecture::Hexagon => Keystone::new(Arch::HEXAGON, Mode::MODE_32),
-            Architecture::Mips => Keystone::new(Arch::MIPS, Mode::MIPS32),
-            Architecture::Mips64 => Keystone::new(Arch::MIPS, Mode::MIPS64),
-            Architecture::PowerPc => Keystone::new(Arch::PPC, Mode::PPC32),
-            Architecture::PowerPc64 => Keystone::new(Arch::PPC, Mode::PPC64),
-            Architecture::S390x => Keystone::new(Arch::SYSTEMZ, Mode::MODE_32),
-            Architecture::Sparc64 => Keystone::new(Arch::SPARC, Mode::SPARC64),
-            _ => Keystone::new(Arch::X86, Mode::MODE_64),
+            Architecture::Aarch64 => Keystone::new(Arch::ARM64, Mode::LITTLE_ENDIAN).map(|keystone| Encoder::Keystone(keystone)),
+            Architecture::Aarch64_Ilp32 => Keystone::new(Arch::ARM64, Mode::LITTLE_ENDIAN).map(|keystone| Encoder::Keystone(keystone)),
+            Architecture::Arm => Keystone::new(Arch::ARM, Mode::ARM).map(|keystone| Encoder::Keystone(keystone)),
+            Architecture::I386 => Keystone::new(Arch::X86, Mode::MODE_32).map(|keystone| Encoder::Keystone(keystone)),
+            Architecture::X86_64 => Keystone::new(Arch::X86, Mode::MODE_64).map(|keystone| Encoder::Keystone(keystone)),
+            Architecture::X86_64_X32 => Keystone::new(Arch::X86, Mode::MODE_32).map(|keystone| Encoder::Keystone(keystone)),
+            Architecture::Hexagon => Keystone::new(Arch::HEXAGON, Mode::MODE_32).map(|keystone| Encoder::Keystone(keystone)),
+            Architecture::Mips => Keystone::new(Arch::MIPS, Mode::MIPS32).map(|keystone| Encoder::Keystone(keystone)),
+            Architecture::Mips64 => Keystone::new(Arch::MIPS, Mode::MIPS64).map(|keystone| Encoder::Keystone(keystone)),
+            Architecture::PowerPc => Keystone::new(Arch::PPC, Mode::PPC32).map(|keystone| Encoder::Keystone(keystone)),
+            Architecture::PowerPc64 => Keystone::new(Arch::PPC, Mode::PPC64).map(|keystone| Encoder::Keystone(keystone)),
+            Architecture::S390x => Keystone::new(Arch::SYSTEMZ, Mode::MODE_32).map(|keystone| Encoder::Keystone(keystone)),
+            Architecture::Sparc64 => Keystone::new(Arch::SPARC, Mode::SPARC64).map(|keystone| Encoder::Keystone(keystone)),
+            Architecture::Bpf => Ok(Encoder::EBPF),
+            _ => Keystone::new(Arch::X86, Mode::MODE_64).map(|keystone| Encoder::Keystone(keystone)),
         }
     }
 
@@ -229,11 +234,11 @@ impl Header {
         })
     }
 
-    pub fn get_encoder(&self) -> Result<Keystone, Error> {
+    pub fn get_encoder(&self) -> Result<Encoder, Error> {
         match self {
             Header::GenericHeader(header) => Self::get_encoder_for_arch(&header.architecture),
             Header::CustomHeader(header) => Self::get_encoder_for_arch(&header.architecture),
-            Header::None => Keystone::new(Arch::X86, Mode::MODE_64),
+            Header::None => Keystone::new(Arch::X86, Mode::MODE_64).map(|keystone| Encoder::Keystone(keystone)),
         }
     }
 }

--- a/src/headers/mod.rs
+++ b/src/headers/mod.rs
@@ -5,3 +5,4 @@ pub mod bitness;
 pub mod custom_header;
 pub mod generic;
 pub mod section;
+pub mod encoder;

--- a/src/headers/mod.rs
+++ b/src/headers/mod.rs
@@ -3,6 +3,6 @@ pub use header::*;
 
 pub mod bitness;
 pub mod custom_header;
+pub mod encoder;
 pub mod generic;
 pub mod section;
-pub mod encoder;


### PR DESCRIPTION
**Why**
Disassembly and reading EBPF before gave x86-64 syntax as the default assembler was that

**Description:**
Keystone does not support EBPF to assemble, so i've opted to use another crate rbfp and create a wrapper around the assembler, added a new enum that wraps Keystone: Encoder, in this new enum I'ev put Keystone and EBPF (for now). 
